### PR TITLE
Added -i flag to all rm statements, Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,55 @@
-# TLauncher Linux Installer
-Shell scripts for downloading and installing last version of [TLauncher](https://tlauncher.org/) at Linux OS
+# 📘 TLauncher Linux Installer
+Shell script for downloading and installing last version of [TLauncher](https://tlauncher.org/) on Linux OS.
 
-# OS
-  Successfuly tested on 
+## OS
+Successfuly tested on:
   - Ubuntu 20.04 LTS, KDE
   - Ubuntu 18.04 LTS, Gnome
 
-# Requirements
-Install these packages before install
+## Requirements
+Install these packages before continuing further:
+- `curl`
+- `unzip`
+- `openjdk-8-jre`
+- `openjfx`
 
-- curl
-- unzip
-- openjdk-8-jre 
-- openjfx
-
-# Important!
+## Important!
 TLauncher asks for root rights due to fact that if you run without root privileges,
-then there are problems with the graphics (gpu)<br>
-You may check README for more info [Download](https://tlauncher.org/jar)
+there will be problems with the graphics (GPU).\
+You may check the [TLauncher README](https://tlauncher.org/jar) for more info.
 
-# Install
- 1. Download `TLauncher-Installer.zip` from [releases page](https://github.com/Korzinkayablok/TLauncer-Installer/releases/)
- 2. unzip
- 3. `cd TLauncer-Installer`<br> 
- 4. `chmod a+x setup.sh`<br>
- 5. If you only one java 8 version installed on your system run this command`./setup.sh` 
- <br>OR<br>
- Specify java 8 binary path using -j flag. Example `./setup.sh -j /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java`<br><br>
- On Ubuntu 20.04 you can get paths to all java bin by using this command: `update-alternatives --list java`
+## Install
+1.  Clone the repository and move to it:
+```sh
+git clone git@github.com:IvanivAnton/TLauncer-Linux-Installer.git
+cd TLauncer-Linux-Installer
+```
+3. Give the root right to the script:
+```sh
+chmod a+x setup.sh
+```
+4. Execute the script. You will have to either:
+    - Move the `.jar` file at the root of the repository, then execute `./setup.sh`
+      OR
+    - Specify java 8 binary path using the `-j` flag. Example:
+      ```sh
+      ./setup.sh -j /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      ```
+      On `Ubuntu 20.04`, you can get paths to all java binaries by using this command: `update-alternatives --list java`.
+<br>
+
+⚠️ **Careful!** During the execution of `setup.py`, you will be prompted by `rm -rf` statements. Respond `y` if you want the file deleted, or `n` if not.
 
 # Proxy
-Use option `-p` in order to add use proxy during TLanuncher download `-p [protocol://]host[:port] Use this proxy` <br>
+Use option `-p` in order to add use proxy during TLanuncher download `-p [protocol://]host[:port] Use this proxy`.\
 See `curl --help proxy` option name is `--proxy`
 
-You can use `export https_proxy="place-your-proxy-here"` also
+You can also use `export https_proxy="place-your-proxy-here"`.
 
 # Logs
-You can check logs in dist derictory of installation path: /home/TLauncher-\*.\*/dist/TLauncher.out
+You can check logs in the `dist/` directory of installation path: `/home/TLauncher-\*.\*/dist/TLauncher.out`
 
 # Contacts
-Author: Ivaniv Anton 
+Author: Ivaniv Anton
 <br>
 Email: anton.o.ivaniv@gmail.com

--- a/setup.sh
+++ b/setup.sh
@@ -18,14 +18,14 @@ done
 
 curl https://tlauncher.org/jar -L --output TLauncher.zip --proxy "${proxy}"
 unzip -o TLauncher.zip
-rm -f TLauncher.zip README-EN.txt README-RUS.txt
+rm -fi TLauncher.zip README-EN.txt README-RUS.txt
 
 TLauncherName=$(basename *.jar .jar)
 TLauncherDir="$HOME/${TLauncherName}"
 TLauncherDist="$TLauncherDir/dist"
 TLauncherLogFileName="TLauncher.out"
 
-rm -rf $TLauncherDir
+rm -rfi $TLauncherDir
 mkdir $TLauncherDir
 mkdir "$TLauncherDir/dist"
 
@@ -34,7 +34,7 @@ cp ./dist/TLauncher.sh "$TLauncherDir/dist"
 cp ./dist/TLauncher.desktop $TLauncherDir
 cp $TLauncherName.jar "$TLauncherDir/dist"
 
-rm -f *.jar
+rm -fi *.jar
 cd "$TLauncherDir/dist"
 touch ${TLauncherLogFileName}
 
@@ -52,6 +52,6 @@ sed -i 's|TLauncherName|'"$TLauncherName"'|g' ./TLauncher.desktop
 chmod a+x TLauncher.desktop
 mv TLauncher.desktop "${TLauncherName}.desktop"
 
-rm -f "$HOME/.local/share/applications/${TLauncherName}.desktop"
+rm -fi "$HOME/.local/share/applications/${TLauncherName}.desktop"
 cp "${TLauncherName}.desktop" "$HOME/.local/share/applications/"
 chmod a+x "$HOME/.local/share/applications/${TLauncherName}.desktop"


### PR DESCRIPTION
### PR created after issue #9 

After getting my PC's home directory wiped out, I decided to modify some of the code for it to be safer.

What caused the issue was this part of the code:
```
TLauncherName=$(basename *.jar .jar)
TLauncherDir="$HOME/${TLauncherName}"

[...]

rm -rf $TLauncherDir
```
Firstly, you should never assume that the user wants the `TLauncherDir` elsewhere than in the repository. Creating a flag for the script to adapt to this would be a great addition.
Next, note this: if there is no `.jar` file in the repository's directory, the `TLauncherName` variable will be set to `*` (try running `echo $(basename *.jar .jar)` in the cloned repository). The problem comes here: `TLauncherDir` is then set to `$HOME/*`
The `rm -rf $TLauncherDir` statement then deletes recursively `$HOME/*`, that is every folder existing in the user's home directory.

The addition of a `-i` flag to each `rm` statements is what allows the user to **see** each file that is about to get deleted, and refuse its deletion if an error occurs. I made sure the README explains it too:
"⚠️ **Careful!** During the execution of `setup.py`, you will be prompted by `rm -rf` statements. Respond `y` if you want the file deleted, or `n` if not."